### PR TITLE
Removing datadog tracing since its bundled with latest dd-agent

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,13 +17,6 @@ datadog_group: root
 # default apt repo
 datadog_apt_repo: "deb http://apt.datadoghq.com/ stable main"
 
-# default install datadog tracing agent
-datadog_trace: False
-
-# temporary hardcoded datadog agents until tracing is fully integrated
-datadog_agent_version: datadog-agent-5.10.1-1
-datadog_trace_agent_version: dd-trace-agent-0.99.62-1
-
 datadog_mysql_host: localhost
 datadog_mysql_user: datadog
 datadog_mysql_password: ThisNeedsToBeChangedViaVault

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,3 @@
 ---
 - name: restart datadog-agent
   service: name=datadog-agent state=restarted
-
-- name: restart datadog-trace-agent
-  service: name=dd-trace-agent state=restarted

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -3,22 +3,9 @@
   template: src=datadog.repo.j2 dest=/etc/yum.repos.d/datadog.repo owner=root group=root mode=0644
 
 - name: Install datadog-agent package
-  yum: name={{ datadog_agent_version }} state=present enablerepo=datadog
+  yum: name=datadog-agent state=latest enablerepo=datadog
   notify: restart datadog-agent
 
 - name: Configure datadog-agent
   template: src=datadog.conf.j2 dest=/etc/dd-agent/datadog.conf
   notify: restart datadog-agent
-
-- name: Update yum cache
-  command: sudo yum makecache
-  when: datadog_trace
-
-- name: Copy trace repo file into place
-  template: src=datadog-trace.repo.j2 dest=/etc/yum.repos.d/datadog-trace.repo owner=root group=root mode=0644
-  when: datadog_trace
-
-- name: Install datadog-trace agent
-  yum: name={{ datadog_trace_agent_version }} state=present enablerepo=datadog
-  when: datadog_trace
-  notify: restart datadog-trace-agent

--- a/templates/datadog-trace.repo.j2
+++ b/templates/datadog-trace.repo.j2
@@ -1,7 +1,0 @@
-[datadog-trace]
-name = Datadog, Inc.
-baseurl = http://yum-trace.datad0g.com.s3.amazonaws.com/x86_64/
-enabled=1
-priority=1
-gpgcheck=1
-gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public


### PR DESCRIPTION
@udemy/sre 

Removing datadog tracing since it is now bundled in with the latest dd-agent.

This change shouldn't be merged until website-django and ansible requirements are ready to be updated and rolled out. 