### PR TITLE
Adding NTP as a default datadog check

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,13 @@ datadog_enabled: yes
 datadog_config: {}
 
 # default checks enabled
-datadog_checks: {}
+datadog_checks:
+  ntp:
+    init_config:
+    instances:
+      - offset_threshold: 60
+        host: infra102.int.udemy.com
+        port: ntp
 
 # default checks enabled
 datadog_check_agents: {}


### PR DESCRIPTION
Adding NTP as a default datadog check since it is being used by all service with datadog running on it. 

This was formerly part of the monitoring role as:
- name: Install NTP settings for datadog
  copy: src=datadog/ntp.yaml dest=/etc/dd-agent/conf.d/ntp.yaml
  notify: restart datadog-agent
  tags: ntp

