### PR TITLE
Revert "Adding NTP as a default datadog check"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,13 +5,7 @@ datadog_enabled: yes
 datadog_config: {}
 
 # default checks enabled
-datadog_checks:
-  ntp:
-    init_config:
-    instances:
-      - offset_threshold: 60
-        host: infra102.int.udemy.com
-        port: ntp
+datadog_checks: {}
 
 # default checks enabled
 datadog_check_agents: {}


### PR DESCRIPTION
Reverts udemy/ansible-datadog#6