### PR TITLE
Hardcoding the datadog-agent version as a precaution

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,8 @@ datadog_group: root
 # default apt repo
 datadog_apt_repo: "deb http://apt.datadoghq.com/ stable main"
 
+datadog_agent_version: datadog-agent-5.11.2-1
+
 datadog_mysql_host: localhost
 datadog_mysql_user: datadog
 datadog_mysql_password: ThisNeedsToBeChangedViaVault

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -9,4 +9,4 @@
 
 - apt_repository: repo='{{ datadog_apt_repo }}' state=present update_cache=yes
 
-- apt: name=datadog-agent state=latest
+- apt: name={{ datadog_agent_version }} state=present enablerepo=datadog

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -6,7 +6,7 @@
   yum: name=dd-trace-agent state=removed
 
 - name: Install datadog-agent package
-  yum: name=datadog-agent state=latest enablerepo=datadog
+  yum: name={{ datadog_agent_version }} state=present enablerepo=datadog
   notify: restart datadog-agent
 
 - name: Configure datadog-agent


### PR DESCRIPTION
Hardcoding the datadog agent version for safety. This is the version currently installed on our hosts;
datadog-agent-5.11.2-1.x86_64