### PR TITLE
Adding custom check for docker swarm

### DIFF
--- a/files/docker_swarm.py
+++ b/files/docker_swarm.py
@@ -1,0 +1,21 @@
+import socket
+import subprocess
+
+from checks import AgentCheck
+
+
+class DockerSwarm(AgentCheck):
+
+    def check(self, instance):
+        metric = "docker_swarm.running"
+        host_name = socket.gethostbyname(socket.gethostname())
+        tag = 'host:%s' % host_name
+
+        pipes = subprocess.Popen("sudo docker node ls",stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        std_out, std_err = pipes.communicate()
+        returncode = pipes.returncode
+
+        if returncode:
+            self.gauge(metric, returncode, tags=[tag])
+        else:
+            self.gauge(metric, -1, tags=[tag])


### PR DESCRIPTION
Adding a custom check to ensure docker swarm is initialized. 

The simply returns the response code from the 'docker node ls' command which returns whether the docker instance is a swarm manager or not. Will return 0 if it is a swarm manager, and 1 if it is not. 

We can then create a monitor to alert if all metrics are 1 - which would indicates docker isn't running in swarm. 