### PR TITLE
[apt] Remove expired key from role (#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Role Variables
 `datadog_checks` instead)
 - `datadog_apt_repo` - Override default Datadog `apt` repository
 - `datadog_apt_key_url` - Override default url to Datadog `apt` key
-- `datadog_apt_key_url_new` - Override default url to the new Datadog `apt` key (in the near future the `apt` repo will have to be checked against this new key instead of the current key)
+- `datadog_apt_key_url_new` - Override default url to Datadog `apt` key (key ID `382E94DE` ; the deprecated `datadog_apt_key_url` variable refers to an expired key that's been removed from the role)
 - `datadog_allow_agent_downgrade` - Set to `yes` to allow agent downgrades on apt-based platforms (use with caution, see `defaults/main.yml` for details)
 
 Dependencies

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -15,14 +15,6 @@
   apt_key: id=A2923DFF56EDA6E76E55E492D3A80E30382E94DE url={{ datadog_apt_key_url_new }} state=present
   when: datadog_apt_key_url_new is defined
 
-- name: Ensure ubuntu apt-key server is present
-  apt_key: id=C7A7DA52 keyserver=hkp://keyserver.ubuntu.com:80 state=present
-  when: datadog_apt_key_url is not defined
-
-- name: Ensure Datadog apt-key is present
-  apt_key: id=C7A7DA52 url={{ datadog_apt_key_url }} state=present
-  when: datadog_apt_key_url is defined
-
 - name: Ensure Datadog repository is up-to-date
   apt_repository: repo='{{ datadog_apt_repo }}' state=present update_cache=yes
 


### PR DESCRIPTION
Was breaking runs since Ansible ignores expired keys, and therefore
doesn't detect the import was successful