### PR TITLE
Our hack to install custom check scripts was removed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,16 @@
 - include: agent6.yml
   when: datadog_agent6
 
+- name: Create a check agent for each Datadog check
+  copy:
+    src={{ item }}.py
+    dest=/etc/dd-agent/checks.d/{{ item }}.py
+    owner={{ datadog_user }}
+    group={{ datadog_group }}
+  with_items: '{{ datadog_check_agents }}'
+  notify:
+   - restart datadog-agent
+
 - name: Upgrade snakebite version
   pip:
     name: snakebite


### PR DESCRIPTION
@udemy/sre we added this hack a while ago to allow us to install custom python checks on our hosts. This was accidentally removed somehow, so I'm adding it back. The reason I'm adding it to the main.yml rather than datadog_agent5/6 is because it's the same logic in both :) 

This is the reason that we weren't receiving uwsgi metrics during the DR: https://udemyjira.atlassian.net/browse/AD-421
