### PR TITLE
Adding task to add dd-agent user to specific group

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@ datadog_checks: {}
 # default check agents enabled
 datadog_check_agents: {}
 
+# default groups to add dd-agent system user to
+datadog_groups: {}
+
 # default user/group
 datadog_user: dd-agent
 datadog_group: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,10 +13,10 @@
 
 - name: Create a check agent for each Datadog check
   copy:
-    src={{ item }}.py
-    dest=/etc/dd-agent/checks.d/{{ item }}.py
-    owner={{ datadog_user }}
-    group={{ datadog_group }}
+    src: {{ item }}.py
+    dest: /etc/dd-agent/checks.d/{{ item }}.py
+    owner: {{ datadog_user }}
+    group: {{ datadog_group }}
   with_items: '{{ datadog_check_agents }}'
   notify:
    - restart datadog-agent
@@ -31,7 +31,9 @@
   notify: restart datadog-agent
 
 - name: Install perl-DBD-MySQL
-  yum: state=present name=perl-DBD-MySQL
+  yum:
+    state: present
+    name: perl-DBD-MySQL
   when: mysql_server_monitoring is defined and mysql_server_monitoring
 
 - mysql_db: name=datadog state=present
@@ -43,3 +45,9 @@
     state: present
   when: data_server_monitoring is defined and data_server_monitoring
 
+- name: Adding datadog system user to {{ item }} group
+  user:
+    name: {{ datadog_user }}
+    groups: {{ item }}
+    append: yes
+  with_items: '{{ datadog_groups }}'


### PR DESCRIPTION
@udemy/sre in order to use the Varnish integration for Datadog we need to add the dd-agent system user to the Varnish group. I've done it manually using this command "sudo usermod -G varnish -a dd-agent" and now I am ansibilizing it. 