### PR TITLE
Enable the service as the last step

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,12 +5,6 @@
 - include: pkg-redhat.yml
   when: ansible_os_family == "RedHat"
 
-- include: agent5.yml
-  when: not datadog_agent6
-
-- include: agent6.yml
-  when: datadog_agent6
-
 - name: Create a check agent for each Datadog check
   copy:
     src: "{{ item }}.py"
@@ -36,7 +30,9 @@
     name: perl-DBD-MySQL
   when: mysql_server_monitoring is defined and mysql_server_monitoring
 
-- mysql_db: name=datadog state=present
+- mysql_db:
+    name: datadog
+    state: present
   when: data_server_monitoring is defined and data_server_monitoring
 
 - mysql_user:
@@ -51,3 +47,9 @@
     groups: "{{ item }}"
     append: yes
   with_items: "{{ datadog_groups }}"
+
+- include: agent5.yml
+  when: not datadog_agent6
+
+- include: agent6.yml
+  when: datadog_agent6


### PR DESCRIPTION
To: @udemy/sre 

What:
The `agent5.yml` and `agent6.yml` contain the task to start the service. So if we do any modification after the the start of the service, we need to rely on the handler (which can have issues with broken playbook runs).
Therefore let's move start/enable steps as the last one in the role.

Ticket:
https://udemyjira.atlassian.net/browse/SRE-1384
