### PR TITLE
Fix config permissions

### DIFF
--- a/tasks/agent6.yml
+++ b/tasks/agent6.yml
@@ -10,6 +10,7 @@
     dest: /etc/datadog-agent/datadog.yaml
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
+    mode: 0640
   notify: restart datadog-agent
 
 - name: Ensure configuration directories are present for each Datadog check

--- a/tasks/agent6.yml
+++ b/tasks/agent6.yml
@@ -26,6 +26,7 @@
     dest: "/etc/datadog-agent/conf.d/{{ item }}.d/conf.yaml"
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
+    mode: 0640
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent
 


### PR DESCRIPTION
To:
@udemy/sre 

What:
We keep credentials in these configuration files, so we should limit the access to them.
Upstream is actually done this recently: https://github.com/DataDog/ansible-datadog/pull/313